### PR TITLE
feat: Split Router and Route

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,3 @@
-
 # rtl-react-router-utils
 
 A `withRouter` helper for using with `rtl-utils`.
@@ -6,10 +5,20 @@ A `withRouter` helper for using with `rtl-utils`.
 ```tsx
 import { withRouter } from "@homebound/rtl-react-router-utils";
 
-const router = withRouter("/currentPage", "/:path");
-const { button } = await render(
-  <FooPage />,
-  router);
+const router = withRouter("/currentPage");
+const { button } = await render(<FooPage />, router);
+click(button);
+expect(router.history.location.pathname).toEqual("/somethingElse");
+```
+
+A `withRoute` helper for using with `rtl-utils`.
+
+```tsx
+import { withRoute, withRouter } from "@homebound/rtl-react-router-utils";
+
+const router = withRouter("/currentPage");
+const route = withRoute("/:path");
+const { button } = await render(<FooPage />, route, router);
 click(button);
 expect(router.history.location.pathname).toEqual("/somethingElse");
 ```

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -1,30 +1,63 @@
 import React from "react";
 import { useParams, useRouteMatch } from "react-router";
-import { withRouter } from "./index";
+import { withRoute, withRouter } from "./index";
 import { useQueryParam, StringParam } from "use-query-params";
 import { render } from "@testing-library/react";
 
 describe("renderRouter", () => {
-  it("withRouter supports useParams, useRouteMatch, and useQueryParam hooks", async () => {
-    const router = withRouter(fooUrlWithParam, fooPath);
-    const { getByTestId } = render(router.wrap(<FooPage />));
-    expect(router.history.location.pathname).toBe(fooUrl);
-    expect(getByTestId("id").innerHTML).toEqual("1");
-    expect(getByTestId("url").innerHTML).toEqual(fooUrl);
-    expect(getByTestId("param").innerHTML).toEqual("test");
+  it("withRouter provides expected defaults", () => {
+    // Given withRouter used without an explicit url
+    // When component rendered
+    const { getByTestId } = render(withRouter().wrap(<FooPage />));
+    // Then url is root
+    expect(getByTestId("url").innerHTML).toEqual("/");
   });
 
-  it("withRouter renders without requiring a path", async () => {
-    const { getByTestId } = render(withRouter(fooUrlWithParam).wrap(<FooPage />));
+  it("withRouter renders without requiring a path", () => {
+    // Given withRouter provided an explicit url and is used without withRoute
+    const router = withRouter(fooUrlWithParam);
+    // When component is rendered
+    const { getByTestId } = render(router.wrap(<FooPage />));
+    // Then url is correct
+    expect(router.history.location.pathname).toBe(fooUrl);
     expect(getByTestId("url").innerHTML).toEqual("/");
+    // and param is correct
     expect(getByTestId("param").innerHTML).toEqual("test");
-    // Cannot match `id` as we didn't specify a `path` for matching against
+    // and there is no match for `id` as we didn't specify withRoute
     expect(getByTestId("id").innerHTML).toEqual("");
   });
 
-  it("withRouter provides expected defaults", async () => {
-    const { getByTestId } = await render(withRouter().wrap(<FooPage />));
-    expect(getByTestId("url").innerHTML).toEqual("/");
+  it("withRoute throws when not wrapped by router", async () => {
+    // note: test passes but still showing asserted error in console without spy
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    // Given route is not wrapped by router when the component is rendered then an error is thrown
+    await expect(async () => render(withRoute().wrap(<FooPage />))).rejects.toThrowError(
+      "Invariant failed: You should not use <Route> outside a <Router>",
+    );
+    spy.mockClear();
+  });
+
+  it("withRoute provides expected defaults", () => {
+    // Given withRoute used without an explicit path
+    // When component rendered
+    const { getByTestId } = render(withRouter().wrap(withRoute().wrap(<FooPage />)));
+    // Then route path is an empty string
+    expect(getByTestId("id").innerHTML).toEqual("");
+  });
+
+  it("withRouter and withRoute supports useParams, useRouteMatch, and useQueryParam hooks", () => {
+    // Given withRouter and withRoute are used to wrap component
+    const router = withRouter(fooUrlWithParam);
+    const route = withRoute(fooPath);
+    // When component is rendered
+    const { getByTestId } = render(router.wrap(route.wrap(<FooPage />)));
+    // Then url is correct
+    expect(router.history.location.pathname).toBe(fooUrl);
+    expect(getByTestId("url").innerHTML).toEqual(fooUrl);
+    // and param is correct
+    expect(getByTestId("param").innerHTML).toEqual("test");
+    // and there is a match for `id` as path was provided
+    expect(getByTestId("id").innerHTML).toEqual("1");
   });
 });
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,29 +9,26 @@ interface Wrapper {
 }
 
 /**
- * Applies Router, Route (if `route` is provided), and QueryParamProvider wrappers.
+ * Applies Router and QueryParamProvider wrappers.
  *
- * I.e. `route` is the pattern like `/books/:id` and `url` is a specific `/books/b:1`.
+ * I.e. `url` is a specific `/books/b:1`
  */
-export function withRouter(url: string = "/", route?: string): Wrapper & { history: MemoryHistory } {
+export function withRouter(url: string = "/"): Wrapper & { history: MemoryHistory } {
   const history = createMemoryHistory({ initialEntries: [url] });
-
-  // If the user passes `route`, wrap in a `Route` so that the matched params
-  // get auto-added to their props. Otherwise, don't add a `Route` because it
-  // can mess up tests that are specifically testing `Route` behavior.
-  const wrap: Wrapper["wrap"] = route
-    ? (c) => (
-        <Router history={history}>
-          <Route path={route}>
-            <QueryParamProvider ReactRouterRoute={Route}>{c}</QueryParamProvider>
-          </Route>
-        </Router>
-      )
-    : (c) => (
-        <Router history={history}>
-          <QueryParamProvider ReactRouterRoute={Route}>{c}</QueryParamProvider>
-        </Router>
-      );
-
+  const wrap: Wrapper["wrap"] = (c) => (
+    <Router history={history}>
+      <QueryParamProvider ReactRouterRoute={Route}>{c}</QueryParamProvider>
+    </Router>
+  );
   return { history, wrap };
+}
+
+/**
+ * Applies Route wrapper.
+ *
+ * I.e. `route` is the pattern like `/books/:id`
+ */
+export function withRoute(route: string = ""): Wrapper {
+  const wrap: Wrapper["wrap"] = (c) => <Route path={route}>{c}</Route>;
+  return { wrap };
 }


### PR DESCRIPTION
Provide the ability for implementor to specify where in the react DOM tree the `Router` and `Route` are rendered instead of coupling them together.

When being implemented in `rtl-utils` this allows us to define our wrappers as such:
```
result = await rtlRender(component, {
   // The route wraps {c}, then modal wraps route then withBeamRTL wraps modal and so on
   wrappers: [route, ...maybeModal, withBeamRTL, router, apollo, ...wrappers],
   wait,
});
 ```
allowing the opportunity to place other components / context between the `Router` and `Route`.